### PR TITLE
feat: improve services unit accuracy and fallback

### DIFF
--- a/frontend/src/pages/ServicesPage.tsx
+++ b/frontend/src/pages/ServicesPage.tsx
@@ -95,11 +95,7 @@ export function ServicesPage() {
                         </CardHeader>
                         <CardContent className="space-y-2 pt-0">
                             <p className="font-mono text-xs text-muted-foreground">Port {service.port}</p>
-                            {service.unit ? (
-                                <p className="font-mono text-xs text-muted-foreground">Unit: {service.unit}</p>
-                            ) : (
-                                <p className="font-mono text-xs text-muted-foreground">Unit not detected on this machine</p>
-                            )}
+                            <p className="font-mono text-xs text-muted-foreground">Unit: {service.unit || "N/A"}</p>
                         </CardContent>
                     </Card>
                 ))}

--- a/internal/infra/services/linux/provider.go
+++ b/internal/infra/services/linux/provider.go
@@ -3,6 +3,7 @@ package linux
 import (
 	"context"
 	"sort"
+	"strconv"
 	"strings"
 
 	"phant/internal/domain/servicesstatus"
@@ -10,20 +11,22 @@ import (
 )
 
 type serviceDefinition struct {
-	ID          string
-	Label       string
-	Description string
-	Port        int
-	Unit        string
+	ID           string
+	Label        string
+	Description  string
+	Port         int
+	UnitNames    []string
+	UnitPrefixes []string
+	Processes    []string
 }
 
 var defaultServices = []serviceDefinition{
-	{ID: "postgresql", Label: "PostgreSQL", Description: "PostgreSQL database server", Port: 5432, Unit: "postgresql.service"},
-	{ID: "mysql", Label: "MySQL", Description: "MySQL database server", Port: 3306, Unit: "mysql.service"},
-	{ID: "mariadb", Label: "MariaDB", Description: "MariaDB database server", Port: 3306, Unit: "mariadb.service"},
-	{ID: "valkey", Label: "Valkey", Description: "Valkey key-value store", Port: 6379, Unit: "valkey.service"},
-	{ID: "redis", Label: "Redis", Description: "Redis key-value store", Port: 6379, Unit: "redis.service"},
-	{ID: "mailpit", Label: "Mailpit", Description: "Mailpit email testing server", Port: 1025, Unit: "mailpit.service"},
+	{ID: "postgresql", Label: "PostgreSQL", Description: "PostgreSQL database server", Port: 5432, UnitNames: []string{"postgresql.service"}, UnitPrefixes: []string{"postgresql@", "postgresql."}, Processes: []string{"postgres"}},
+	{ID: "mysql", Label: "MySQL", Description: "MySQL database server", Port: 3306, UnitNames: []string{"mysql.service", "mysqld.service"}, UnitPrefixes: []string{"mysql@", "mysql.", "mysqld@", "mysqld."}, Processes: []string{"mysqld", "mariadbd"}},
+	{ID: "mariadb", Label: "MariaDB", Description: "MariaDB database server", Port: 3306, UnitNames: []string{"mariadb.service"}, UnitPrefixes: []string{"mariadb@", "mariadb."}, Processes: []string{"mariadbd", "mysqld"}},
+	{ID: "valkey", Label: "Valkey", Description: "Valkey key-value store", Port: 6379, UnitNames: []string{"valkey.service"}, UnitPrefixes: []string{"valkey@", "valkey."}, Processes: []string{"valkey-server"}},
+	{ID: "redis", Label: "Redis", Description: "Redis key-value store", Port: 6379, UnitNames: []string{"redis.service", "redis-server.service"}, UnitPrefixes: []string{"redis@", "redis.", "redis-server@", "redis-server."}, Processes: []string{"redis-server"}},
+	{ID: "mailpit", Label: "Mailpit", Description: "Mailpit email testing server", Port: 1025, UnitNames: []string{"mailpit.service"}, UnitPrefixes: []string{"mailpit@", "mailpit."}, Processes: []string{"mailpit"}},
 }
 
 type Provider struct {
@@ -48,7 +51,6 @@ func (p *Provider) DiscoverServices(ctx context.Context) ([]servicesstatus.Servi
 				Label:       def.Label,
 				Description: def.Description,
 				Port:        def.Port,
-				Unit:        def.Unit,
 				State:       servicesstatus.StateUnavailable,
 			})
 		}
@@ -56,30 +58,42 @@ func (p *Provider) DiscoverServices(ctx context.Context) ([]servicesstatus.Servi
 		return statuses, []string{"systemctl is unavailable on this machine"}, nil
 	}
 
+	installedUnits, err := p.readInstalledUnits(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	statuses := make([]servicesstatus.ServiceStatus, 0, len(defaultServices))
+	portsByProcess := p.readListeningPortsByProcess(ctx)
 	for _, def := range defaultServices {
-		statuses = append(statuses, p.inspectService(ctx, def))
+		statuses = append(statuses, p.inspectService(ctx, def, installedUnits, portsByProcess))
 	}
 
 	sortStatuses(statuses)
 	return statuses, nil, nil
 }
 
-func (p *Provider) inspectService(ctx context.Context, def serviceDefinition) servicesstatus.ServiceStatus {
+func (p *Provider) inspectService(
+	ctx context.Context,
+	def serviceDefinition,
+	installedUnits map[string]struct{},
+	portsByProcess map[string]int,
+) servicesstatus.ServiceStatus {
 	status := servicesstatus.ServiceStatus{
 		ID:          def.ID,
 		Label:       def.Label,
 		Description: def.Description,
 		Port:        def.Port,
-		Unit:        def.Unit,
 	}
 
-	if !p.unitExists(ctx, def.Unit) {
+	unitName, exists := resolveInstalledUnit(def, installedUnits)
+	if !exists {
 		status.State = servicesstatus.StateUnavailable
 		return status
 	}
+	status.Unit = unitName
 
-	activeState, err := p.readActiveState(ctx, def.Unit)
+	activeState, err := p.readActiveState(ctx, unitName)
 	if err != nil {
 		status.State = servicesstatus.StateStopped
 		return status
@@ -87,6 +101,9 @@ func (p *Provider) inspectService(ctx context.Context, def serviceDefinition) se
 
 	if activeState == "active" {
 		status.State = servicesstatus.StateRunning
+		if detectedPort, ok := detectPort(def.Processes, portsByProcess); ok {
+			status.Port = detectedPort
+		}
 		return status
 	}
 
@@ -94,18 +111,27 @@ func (p *Provider) inspectService(ctx context.Context, def serviceDefinition) se
 	return status
 }
 
-func (p *Provider) unitExists(ctx context.Context, unit string) bool {
-	stdout, err := p.runner.Run(ctx, "systemctl", "list-unit-files", "--type=service", "--no-legend", "--plain", unit)
+func (p *Provider) readInstalledUnits(ctx context.Context) (map[string]struct{}, error) {
+	stdout, err := p.runner.Run(ctx, "systemctl", "list-unit-files", "--type=service", "--no-legend", "--plain")
 	if err != nil {
-		return false
+		return nil, err
 	}
 
-	line := strings.TrimSpace(stdout)
-	if line == "" {
-		return false
+	units := make(map[string]struct{})
+	for _, line := range strings.Split(stdout, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+
+		unitName := strings.TrimSpace(fields[0])
+		if !strings.HasSuffix(unitName, ".service") {
+			continue
+		}
+		units[unitName] = struct{}{}
 	}
 
-	return strings.Contains(line, unit)
+	return units, nil
 }
 
 func (p *Provider) readActiveState(ctx context.Context, unit string) (string, error) {
@@ -120,4 +146,112 @@ func sortStatuses(statuses []servicesstatus.ServiceStatus) {
 	sort.Slice(statuses, func(i, j int) bool {
 		return statuses[i].Label < statuses[j].Label
 	})
+}
+
+func (p *Provider) readListeningPortsByProcess(ctx context.Context) map[string]int {
+	stdout, err := p.runner.Run(ctx, "ss", "-ltnpH")
+	if err != nil || strings.TrimSpace(stdout) == "" {
+		return map[string]int{}
+	}
+
+	portsByProcess := map[string]int{}
+	for _, line := range strings.Split(stdout, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+
+		localAddress := fields[3]
+		port, ok := parsePort(localAddress)
+		if !ok {
+			continue
+		}
+
+		processField := strings.Join(fields[5:], " ")
+		for _, process := range extractProcessNames(processField) {
+			if _, exists := portsByProcess[process]; !exists {
+				portsByProcess[process] = port
+			}
+		}
+	}
+
+	return portsByProcess
+}
+
+func detectPort(processes []string, portsByProcess map[string]int) (int, bool) {
+	for _, process := range processes {
+		if port, ok := portsByProcess[process]; ok {
+			return port, true
+		}
+	}
+
+	return 0, false
+}
+
+func parsePort(localAddress string) (int, bool) {
+	separator := strings.LastIndex(localAddress, ":")
+	if separator == -1 || separator == len(localAddress)-1 {
+		return 0, false
+	}
+
+	portText := localAddress[separator+1:]
+	if portText == "*" {
+		return 0, false
+	}
+
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		return 0, false
+	}
+
+	return port, true
+}
+
+func extractProcessNames(processField string) []string {
+	names := make([]string, 0)
+	segments := strings.Split(processField, "\"")
+	for i := 1; i < len(segments); i += 2 {
+		name := strings.TrimSpace(segments[i])
+		if name == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+
+	return names
+}
+
+func resolveInstalledUnit(def serviceDefinition, installedUnits map[string]struct{}) (string, bool) {
+	for _, unitName := range def.UnitNames {
+		if _, ok := installedUnits[unitName]; ok {
+			return unitName, true
+		}
+	}
+
+	candidates := make([]string, 0)
+	for installedUnit := range installedUnits {
+		if !strings.HasSuffix(installedUnit, ".service") {
+			continue
+		}
+		if hasAnyPrefix(installedUnit, def.UnitPrefixes) {
+			candidates = append(candidates, installedUnit)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return "", false
+	}
+
+	sort.Strings(candidates)
+	return candidates[0], true
+}
+
+func hasAnyPrefix(value string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(value, prefix) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/infra/services/linux/provider_test.go
+++ b/internal/infra/services/linux/provider_test.go
@@ -24,7 +24,7 @@ func (m mockRunner) Run(_ context.Context, name string, args ...string) (string,
 	if output, ok := m.outputs[key]; ok {
 		return output, nil
 	}
-	return "", errors.New("command not mocked")
+	return "", fmt.Errorf("command not mocked: %s", key)
 }
 
 func (m mockRunner) LookPath(_ string) (string, error) {
@@ -61,9 +61,9 @@ func TestProvider_DiscoverServices_SystemctlUnavailable(t *testing.T) {
 func TestProvider_DiscoverServices_RunningStoppedUnavailable(t *testing.T) {
 	runner := mockRunner{
 		outputs: map[string]string{
-			"systemctl list-unit-files --type=service --no-legend --plain redis.service": "redis.service enabled",
-			"systemctl is-active redis.service":                                          "active",
-			"systemctl list-unit-files --type=service --no-legend --plain mysql.service": "mysql.service enabled",
+			"systemctl list-unit-files --type=service --no-legend --plain": "redis.service enabled\nmysql.service enabled",
+			"systemctl is-active redis.service":                            "active",
+			"ss -ltnpH":                                                    "",
 		},
 		errors: map[string]error{
 			"systemctl is-active mysql.service": errors.New("inactive"),
@@ -87,20 +87,54 @@ func TestProvider_DiscoverServices_RunningStoppedUnavailable(t *testing.T) {
 	if lookup["redis"].State != servicesstatus.StateRunning {
 		t.Fatalf("redis state mismatch: expected running, got %s", lookup["redis"].State)
 	}
+	if lookup["redis"].Unit != "redis.service" {
+		t.Fatalf("redis unit mismatch: expected redis.service, got %s", lookup["redis"].Unit)
+	}
 	if lookup["mysql"].State != servicesstatus.StateStopped {
 		t.Fatalf("mysql state mismatch: expected stopped, got %s", lookup["mysql"].State)
+	}
+	if lookup["mysql"].Unit != "mysql.service" {
+		t.Fatalf("mysql unit mismatch: expected mysql.service, got %s", lookup["mysql"].Unit)
 	}
 	if lookup["mailpit"].State != servicesstatus.StateUnavailable {
 		t.Fatalf("mailpit state mismatch: expected unavailable, got %s", lookup["mailpit"].State)
 	}
 }
 
-func TestProvider_DiscoverServices_EmptyUnitOutputIsUnavailable(t *testing.T) {
+func TestProvider_DiscoverServices_UsesDetectedListeningPort(t *testing.T) {
 	runner := mockRunner{
 		outputs: map[string]string{
-			"systemctl list-unit-files --type=service --no-legend --plain mysql.service": "",
-			"systemctl list-unit-files --type=service --no-legend --plain redis.service": "redis.service enabled",
-			"systemctl is-active redis.service":                                          "active",
+			"systemctl list-unit-files --type=service --no-legend --plain": "redis.service enabled",
+			"systemctl is-active redis.service":                            "active",
+			"ss -ltnpH":                                                    "LISTEN 0 511 127.0.0.1:6380 0.0.0.0:* users:((\"redis-server\",pid=111,fd=6))",
+		},
+	}
+
+	provider := NewProvider(runner)
+	services, warnings, err := provider.DiscoverServices(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverServices() error = %v, want nil", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("DiscoverServices() warnings = %v, want none", warnings)
+	}
+
+	lookup := map[string]servicesstatus.ServiceStatus{}
+	for _, service := range services {
+		lookup[service.ID] = service
+	}
+
+	if got := lookup["redis"].Port; got != 6380 {
+		t.Fatalf("DiscoverServices(redis).Port = %d, want %d", got, 6380)
+	}
+}
+
+func TestProvider_DiscoverServices_MissingUnitIsUnavailable(t *testing.T) {
+	runner := mockRunner{
+		outputs: map[string]string{
+			"systemctl list-unit-files --type=service --no-legend --plain": "redis.service enabled",
+			"systemctl is-active redis.service":                            "active",
+			"ss -ltnpH":                                                    "",
 		},
 	}
 
@@ -123,5 +157,39 @@ func TestProvider_DiscoverServices_EmptyUnitOutputIsUnavailable(t *testing.T) {
 	}
 	if got := lookup["redis"].State; got != servicesstatus.StateRunning {
 		t.Fatalf("DiscoverServices(redis).State = %s, want %s", got, servicesstatus.StateRunning)
+	}
+}
+
+func TestProvider_DiscoverServices_UsesDetectedUnitVariant(t *testing.T) {
+	runner := mockRunner{
+		outputs: map[string]string{
+			"systemctl list-unit-files --type=service --no-legend --plain": "valkey.1.service enabled",
+			"systemctl is-active valkey.1.service":                         "active",
+			"ss -ltnpH":                                                    "LISTEN 0 511 127.0.0.1:6390 0.0.0.0:* users:((\"valkey-server\",pid=111,fd=6))",
+		},
+	}
+
+	provider := NewProvider(runner)
+	services, warnings, err := provider.DiscoverServices(context.Background())
+	if err != nil {
+		t.Fatalf("DiscoverServices() error = %v, want nil", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("DiscoverServices() warnings = %v, want none", warnings)
+	}
+
+	lookup := map[string]servicesstatus.ServiceStatus{}
+	for _, service := range services {
+		lookup[service.ID] = service
+	}
+
+	if got := lookup["valkey"].Unit; got != "valkey.1.service" {
+		t.Fatalf("DiscoverServices(valkey).Unit = %s, want %s", got, "valkey.1.service")
+	}
+	if got := lookup["valkey"].State; got != servicesstatus.StateRunning {
+		t.Fatalf("DiscoverServices(valkey).State = %s, want %s", got, servicesstatus.StateRunning)
+	}
+	if got := lookup["valkey"].Port; got != 6390 {
+		t.Fatalf("DiscoverServices(valkey).Port = %d, want %d", got, 6390)
 	}
 }


### PR DESCRIPTION
## Summary
- detect and return actual installed systemd service unit names (including variant units) in Linux services discovery
- keep dynamic port detection for running services based on listening sockets
- show `Unit: N/A` in Services UI when no unit is detected
- add/update Linux provider tests for resolved unit names and variant unit matching

## Validation
- go test -count=1 ./...
- cd frontend && npm run build
