### PR TITLE
Improve Settings page: reorder sections, inline license reveal, and polish Updates card

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -98,7 +98,7 @@ export function SettingsPage({
         }
 
         if (updateInstallResult?.installed) {
-            return { label: "Installing", variant: "default" as const };
+            return { label: "Installed", variant: "default" as const };
         }
 
         if (downloadingUpdate) {
@@ -181,6 +181,10 @@ export function SettingsPage({
                                 value={licenseKey}
                                 onChange={(event) => onLicenseKeyChange(event.target.value)}
                                 placeholder="PHANT-XXXX-XXXX-XXXX"
+                                autoComplete="new-password"
+                                autoCapitalize="off"
+                                autoCorrect="off"
+                                spellCheck={false}
                                 className="pr-24"
                             />
                             <Button
@@ -246,12 +250,16 @@ export function SettingsPage({
                         <p className="text-sm text-destructive">{updateDownloadResult.error}</p>
                     ) : null}
 
-                    {updateDownloadResult?.downloaded ? (
+                    {hasDownloadedUpdate ? (
                         <div className="space-y-1 rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm text-emerald-500">
                             <p className="font-medium">Update downloaded successfully.</p>
                             <p className="text-muted-foreground">File: {updateDownloadResult.filePath}</p>
                             <p className="text-muted-foreground">Bytes: {updateDownloadResult.bytesWritten}</p>
                         </div>
+                    ) : null}
+
+                    {updateDownloadResult?.downloaded && !updateDownloadResult.filePath ? (
+                        <p className="text-sm text-destructive">Download completed, but file path is missing. Please download again.</p>
                     ) : null}
 
                     {updateInstallResult?.error ? (

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -82,6 +83,49 @@ export function SettingsPage({
             : "min-w-24 border-border/60 bg-transparent text-muted-foreground hover:border-primary/60 hover:text-primary"
     );
 
+    const currentVersion = updateStatus?.currentVersion || appVersion || "unknown";
+    const latestVersion = updateStatus?.latestVersion || updateDownloadResult?.latestVersion || "unknown";
+    const hasDownloadedUpdate = Boolean(updateDownloadResult?.downloaded && updateDownloadResult.filePath);
+    const hasUpdateAvailable = Boolean(updateStatus?.updateAvailable);
+
+    const updateState = (() => {
+        if (updateInstallResult?.error || updateDownloadResult?.error || updateStatus?.error) {
+            return { label: "Error", variant: "destructive" as const };
+        }
+
+        if (installingUpdate) {
+            return { label: "Installing", variant: "secondary" as const };
+        }
+
+        if (updateInstallResult?.installed) {
+            return { label: "Installing", variant: "default" as const };
+        }
+
+        if (downloadingUpdate) {
+            return { label: "Downloading", variant: "secondary" as const };
+        }
+
+        if (hasDownloadedUpdate) {
+            return { label: "Ready to install", variant: "default" as const };
+        }
+
+        if (checkingForUpdates) {
+            return { label: "Checking", variant: "secondary" as const };
+        }
+
+        if (hasUpdateAvailable) {
+            return { label: "Update available", variant: "default" as const };
+        }
+
+        if (updateStatus && !updateStatus.error) {
+            return { label: "Up to date", variant: "outline" as const };
+        }
+
+        return { label: "Not checked", variant: "outline" as const };
+    })();
+
+    const releaseNotes = updateDownloadResult?.notes || updateStatus?.notes || "";
+
     return (
         <div className="space-y-6">
             <PageHeader
@@ -162,38 +206,40 @@ export function SettingsPage({
 
             <Card>
                 <CardHeader>
-                    <CardTitle>Updates</CardTitle>
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                        <CardTitle>Updates</CardTitle>
+                        <Badge variant={updateState.variant}>{updateState.label}</Badge>
+                    </div>
                     <CardDescription>Check for new releases and fetch the latest Linux AppImage.</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
-                    <p className="text-sm text-muted-foreground">Current version: {appVersion || "unknown"}</p>
+                    <div className="grid gap-3 rounded-lg border border-border/60 bg-muted/20 p-4 sm:grid-cols-2">
+                        <div className="space-y-1">
+                            <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">Current</p>
+                            <p className="text-lg font-semibold">{currentVersion}</p>
+                        </div>
+                        <div className="space-y-1">
+                            <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">Latest</p>
+                            <p className="text-lg font-semibold">{latestVersion}</p>
+                        </div>
+                    </div>
 
                     <div className="flex flex-wrap gap-2">
-                        <Button variant="outline" onClick={onCheckForUpdates} disabled={checkingForUpdates}>
+                        <Button variant={hasUpdateAvailable || hasDownloadedUpdate ? "outline" : "default"} onClick={onCheckForUpdates} disabled={checkingForUpdates}>
                             {checkingForUpdates ? "Checking..." : "Check for updates"}
                         </Button>
-                        <Button onClick={onDownloadUpdate} disabled={downloadingUpdate || !updateStatus?.updateAvailable}>
-                            {downloadingUpdate ? "Downloading..." : "Download latest"}
+                        <Button onClick={onDownloadUpdate} disabled={downloadingUpdate || !hasUpdateAvailable}>
+                            {downloadingUpdate ? "Downloading..." : `Download ${latestVersion}`}
                         </Button>
-                        <Button
-                            variant="secondary"
-                            onClick={onInstallUpdate}
-                            disabled={installingUpdate || !updateDownloadResult?.downloaded || !updateDownloadResult.filePath}
-                        >
-                            {installingUpdate ? "Installing..." : "Install & restart"}
-                        </Button>
+                        {hasDownloadedUpdate ? (
+                            <Button variant="secondary" onClick={onInstallUpdate} disabled={installingUpdate}>
+                                {installingUpdate ? "Installing..." : "Install & restart"}
+                            </Button>
+                        ) : null}
                     </div>
 
                     {updateStatus?.error ? (
                         <p className="text-sm text-destructive">{updateStatus.error}</p>
-                    ) : null}
-
-                    {updateStatus && !updateStatus.error ? (
-                        <div className="space-y-1 text-sm text-muted-foreground">
-                            <p>Latest version: {updateStatus.latestVersion || "unknown"}</p>
-                            <p>Status: {updateStatus.updateAvailable ? "Update available" : "Up to date"}</p>
-                            {updateStatus.notes ? <p>Notes: {updateStatus.notes}</p> : null}
-                        </div>
                     ) : null}
 
                     {updateDownloadResult?.error ? (
@@ -201,8 +247,8 @@ export function SettingsPage({
                     ) : null}
 
                     {updateDownloadResult?.downloaded ? (
-                        <div className="space-y-1 text-sm text-emerald-500">
-                            <p>Update downloaded successfully.</p>
+                        <div className="space-y-1 rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm text-emerald-500">
+                            <p className="font-medium">Update downloaded successfully.</p>
                             <p className="text-muted-foreground">File: {updateDownloadResult.filePath}</p>
                             <p className="text-muted-foreground">Bytes: {updateDownloadResult.bytesWritten}</p>
                         </div>
@@ -213,11 +259,18 @@ export function SettingsPage({
                     ) : null}
 
                     {updateInstallResult?.installed ? (
-                        <div className="space-y-1 text-sm text-emerald-500">
-                            <p>{updateInstallResult.message || "Update installation started."}</p>
+                        <div className="space-y-1 rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm text-emerald-500">
+                            <p className="font-medium">{updateInstallResult.message || "Update installation started."}</p>
                             {updateInstallResult.targetPath ? (
                                 <p className="text-muted-foreground">Target: {updateInstallResult.targetPath}</p>
                             ) : null}
+                        </div>
+                    ) : null}
+
+                    {releaseNotes ? (
+                        <div className="space-y-2 rounded-lg border border-border/60 bg-muted/20 p-4">
+                            <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">What&apos;s new</p>
+                            <p className="text-sm text-muted-foreground">{releaseNotes}</p>
                         </div>
                     ) : null}
                 </CardContent>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -6,6 +6,8 @@ import { useTheme } from "@/components/theme-provider";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { SetupPage } from "@/pages/SetupPage";
 import { ValetPage } from "@/pages/ValetPage";
+import { Eye, EyeOff } from "lucide-react";
+import { useState } from "react";
 import type {
     HookInstallResult,
     SetupDiagnostics,
@@ -70,8 +72,9 @@ export function SettingsPage({
     valetRemediationResult: ValetLinuxRemediationResult | null;
     updateDownloadResult: UpdateDownloadResult | null;
     updateInstallResult: UpdateInstallResult | null;
-}) {
+    }) {
     const { theme, setTheme } = useTheme();
+    const [showLicense, setShowLicense] = useState(false);
 
     const themeButtonClass = (isActive: boolean) => (
         isActive
@@ -84,63 +87,76 @@ export function SettingsPage({
             <PageHeader
                 title="Settings"
                 watermark="CFG"
-                description="Manage diagnostics, Valet behavior, integrations, and appearance."
+                description="Manage appearance, licensing, updates, diagnostics, and recovery tools."
             />
-
-            <div className="space-y-2">
-                <h2 className="text-xl font-semibold">Diagnostics</h2>
-                <p className="text-sm text-muted-foreground">Inspect PHP CLI health and manage hook installation.</p>
-                <SetupPage
-                    embedded
-                    diagnostics={diagnostics}
-                    hookResult={hookResult}
-                    installingHook={installingHook}
-                    onRefresh={onRefreshDiagnostics}
-                    onEnable={onEnableCLIHook}
-                />
-            </div>
-
-            <div className="space-y-2">
-                <h2 className="text-xl font-semibold">Valet</h2>
-                <p className="text-sm text-muted-foreground">Diagnose Valet Linux and apply remediation safely.</p>
-                <ValetPage
-                    embedded
-                    valetVerification={valetVerification}
-                    refreshingValet={refreshingValet}
-                    onRefresh={onRefreshValet}
-                    confirmValetRemediation={confirmValetRemediation}
-                    onConfirm={onConfirmValetRemediation}
-                    applyingValetRemediation={applyingValetRemediation}
-                    onApply={onApplyValetRemediation}
-                    valetRemediationResult={valetRemediationResult}
-                />
-            </div>
 
             <Card>
                 <CardHeader>
-                    <CardTitle>Integrations</CardTitle>
-                    <CardDescription>Connections with external tools and services.</CardDescription>
+                    <CardTitle>Appearance</CardTitle>
+                    <CardDescription>Customize the look and feel of Phant.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <div className="flex flex-wrap gap-4">
+                        <Button
+                            variant="outline"
+                            className={themeButtonClass(theme === "light")}
+                            onClick={() => setTheme("light")}
+                        >
+                            Light
+                        </Button>
+                        <Button
+                            variant="outline"
+                            className={themeButtonClass(theme === "dark")}
+                            onClick={() => setTheme("dark")}
+                        >
+                            Dark
+                        </Button>
+                        <Button
+                            variant="outline"
+                            className={themeButtonClass(theme === "system")}
+                            onClick={() => setTheme("system")}
+                        >
+                            System
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>License</CardTitle>
+                    <CardDescription>Activate Phant and keep your updates eligible.</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
                     <div className="space-y-2">
                         <Label htmlFor="license-key">License key</Label>
-                        <div className="flex flex-col gap-2 sm:flex-row">
+                        <div className="relative">
                             <Input
                                 id="license-key"
+                                type={showLicense ? "text" : "password"}
                                 value={licenseKey}
                                 onChange={(event) => onLicenseKeyChange(event.target.value)}
                                 placeholder="PHANT-XXXX-XXXX-XXXX"
+                                className="pr-24"
                             />
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setShowLicense((value) => !value)}
+                                className="absolute inset-y-0 right-0 h-full px-3 text-muted-foreground hover:text-foreground"
+                            >
+                                {showLicense ? <EyeOff /> : <Eye />}
+                                <span className="ml-2">{showLicense ? "Hide" : "Show"}</span>
+                            </Button>
+                        </div>
+                        <div className="flex items-center justify-between gap-2">
+                            <p className="text-xs text-muted-foreground">
+                                Used for auto-update eligibility and to support Phant development.
+                            </p>
                             <Button onClick={onSaveLicense}>Save</Button>
                         </div>
-                        <p className="text-xs text-muted-foreground">
-                            Used for auto-update eligibility and to support Phant development.
-                        </p>
                     </div>
-                    <p className="text-sm text-muted-foreground">
-                        Integrations are optional connections (for example editors, notifications, or tunnel/share tools).
-                        This section is reserved for upcoming integration toggles.
-                    </p>
                 </CardContent>
             </Card>
 
@@ -207,37 +223,34 @@ export function SettingsPage({
                 </CardContent>
             </Card>
 
-            <Card>
-                <CardHeader>
-                    <CardTitle>Appearance</CardTitle>
-                    <CardDescription>Customize the look and feel of Phant.</CardDescription>
-                </CardHeader>
-                <CardContent>
-                    <div className="flex flex-wrap gap-4">
-                        <Button
-                            variant="outline"
-                            className={themeButtonClass(theme === "light")}
-                            onClick={() => setTheme("light")}
-                        >
-                            Light
-                        </Button>
-                        <Button
-                            variant="outline"
-                            className={themeButtonClass(theme === "dark")}
-                            onClick={() => setTheme("dark")}
-                        >
-                            Dark
-                        </Button>
-                        <Button
-                            variant="outline"
-                            className={themeButtonClass(theme === "system")}
-                            onClick={() => setTheme("system")}
-                        >
-                            System
-                        </Button>
-                    </div>
-                </CardContent>
-            </Card>
+            <div className="space-y-2">
+                <h2 className="text-xl font-semibold">Diagnostics</h2>
+                <p className="text-sm text-muted-foreground">Inspect PHP CLI health and manage hook installation.</p>
+                <SetupPage
+                    embedded
+                    diagnostics={diagnostics}
+                    hookResult={hookResult}
+                    installingHook={installingHook}
+                    onRefresh={onRefreshDiagnostics}
+                    onEnable={onEnableCLIHook}
+                />
+            </div>
+
+            <div className="space-y-2">
+                <h2 className="text-xl font-semibold">Valet</h2>
+                <p className="text-sm text-muted-foreground">Diagnose Valet Linux and apply remediation safely.</p>
+                <ValetPage
+                    embedded
+                    valetVerification={valetVerification}
+                    refreshingValet={refreshingValet}
+                    onRefresh={onRefreshValet}
+                    confirmValetRemediation={confirmValetRemediation}
+                    onConfirm={onConfirmValetRemediation}
+                    applyingValetRemediation={applyingValetRemediation}
+                    onApply={onApplyValetRemediation}
+                    valetRemediationResult={valetRemediationResult}
+                />
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## What Changed:
- Reordered Settings sections to present higher-level, low-risk controls first: Appearance → License → Updates → Diagnostics → Valet.
  - Converted the License input to an inline password-style field with an eye toggle and an adjacent Save action (keeps the value hidden by default but reveals it in-place).
  - Redesigned the Updates card to be more product-focused and less noisy:
    - Added a status Badge (Not checked / Checking / Update available / Downloading / Ready to install / Installing / Error).
    - Replaced free-form text with a compact Current / Latest version summary block.
    - Made action buttons context-aware:
      - `Check for updates` remains available.
      - `Download` changes to `Download <version>` when an update is known.
      - `Install & restart` is only shown once a download is available.
    - Improved success / error callouts and added a dedicated "What's new" release notes block.
    - Used existing UI primitives (Badge, Button) and kept visual language consistent with the app.
  - Small copy tweak to the page header description.

  Why:
  - Provide a clearer, more guided update experience that surfaces the current state up-front and reduces visual noise from actions that aren't relevant yet.
  - Make license management less prominent by default while keeping it quick to reveal/edit inline.
  - Preserve existing behavior and logic while improving UX and visual clarity.

  Files touched:
  - frontend/src/pages/SettingsPage.tsx (main UI changes: reordering sections, inline license reveal, Updates card redesign)
  - no backend or application logic changes; UI-only edits

  Notes:
  - Built the frontend to verify there are no compilation issues (local `npm run build` completed successfully).
  - This change is intentionally UI-focused and minimal in scope to avoid breaking flows; behavior and callbacks remain unchanged.